### PR TITLE
Revision 1

### DIFF
--- a/src/CFDI/CFDI.php
+++ b/src/CFDI/CFDI.php
@@ -159,7 +159,7 @@ class CFDI
     /**
      * Returns the xml with the stamp and certificate attributes.
      *
-     * @return
+     * @return DOMDocument
      */
     protected function xml()
     {

--- a/src/CFDI/CFDI.php
+++ b/src/CFDI/CFDI.php
@@ -13,7 +13,6 @@ namespace Charles\CFDI;
 
 use Charles\CFDI\Node\Comprobante;
 use DOMDocument;
-use DOMElement;
 use XSLTProcessor;
 
 /**

--- a/src/CFDI/CFDI.php
+++ b/src/CFDI/CFDI.php
@@ -64,8 +64,6 @@ class CFDI
      * @param array     $data
      * @param string    $key
      * @param string    $cer
-     *
-     * @return void
      */
     public function __construct($data, $cer, $key)
     {

--- a/src/CFDI/CFDI.php
+++ b/src/CFDI/CFDI.php
@@ -123,7 +123,8 @@ class CFDI
     protected function putSello()
     {
         $this->comprobante->setAtributes(
-            $this->comprobante->getElement(), [
+            $this->comprobante->getElement(),
+            [
                 'Sello' => $this->getSello()
             ]
         );
@@ -149,7 +150,8 @@ class CFDI
     protected function putCertificado()
     {
         $this->comprobante->setAtributes(
-            $this->comprobante->getElement(), [
+            $this->comprobante->getElement(),
+            [
                 'Certificado' => $this->getCertificado()
             ]
         );

--- a/src/CFDI/CFDI.php
+++ b/src/CFDI/CFDI.php
@@ -54,7 +54,7 @@ class CFDI
     /**
      * Comprobante instance.
      *
-     * @var \Charles\CFDI\Comprobante
+     * @var Comprobante
      */
     protected $comprobante;
 

--- a/src/CFDI/Common/Node.php
+++ b/src/CFDI/Common/Node.php
@@ -167,7 +167,7 @@ class Node
     /**
      * Get document.
      *
-     * @return \DOMElement
+     * @return \DOMDocument
      */
     public function getDocument()
     {

--- a/src/CFDI/Common/Node.php
+++ b/src/CFDI/Common/Node.php
@@ -70,7 +70,7 @@ class Node
     /**
      * Add a new node
      *
-     * @return void
+     * @param Node $node
      */
     public function add($node)
     {

--- a/src/CFDI/Common/Node.php
+++ b/src/CFDI/Common/Node.php
@@ -37,14 +37,14 @@ class Node
     /**
      * Node document.
      *
-     * @var \DOMDocument
+     * @var DOMDocument
      */
     protected $document;
 
     /**
      * Node element.
      *
-     * @var \DOMElement
+     * @var DOMElement
      */
     protected $element;
 
@@ -163,7 +163,7 @@ class Node
     /**
      * Get element.
      *
-     * @return \DOMElement
+     * @return DOMElement
      */
     public function getElement()
     {
@@ -173,7 +173,7 @@ class Node
     /**
      * Get document.
      *
-     * @return \DOMDocument
+     * @return DOMDocument
      */
     public function getDocument()
     {

--- a/src/CFDI/Common/Node.php
+++ b/src/CFDI/Common/Node.php
@@ -23,6 +23,12 @@ use DOMNodeList;
 class Node
 {
     /**
+     * Define the node name
+     * @var string
+     */
+    protected $nodeName = '';
+
+    /**
      * Node document.
      *
      * @var \DOMDocument
@@ -215,6 +221,9 @@ class Node
      */
     public function getNodeName()
     {
+        if (! is_string($this->nodeName) || '' === $this->nodeName) {
+            throw new \LogicException('El nodo de la clase ' . get_class($this) . ' no tiene nombre de nodo');
+        }
         return $this->nodeName;
     }
 }

--- a/src/CFDI/Common/Node.php
+++ b/src/CFDI/Common/Node.php
@@ -87,7 +87,8 @@ class Node
 
         if ($wrapperName = $node->getWrapperNodeName()) {
             $wrapperElement = $this->getDirectChildElementByName(
-                $this->element->childNodes, $wrapperName
+                $this->element->childNodes,
+                $wrapperName
             );
 
             if (!$wrapperElement) {
@@ -101,7 +102,8 @@ class Node
             $currentElement = ($wrapperElement) ? $wrapperElement : $this->element ;
 
             $parentNode = $this->getDirectChildElementByName(
-                $currentElement->childNodes, $parentName
+                $currentElement->childNodes,
+                $parentName
             );
 
             if (!$parentNode) {
@@ -109,11 +111,9 @@ class Node
                 $currentElement->appendChild($parentElement);
                 $parentElement->appendChild($nodeElement);
                 $this->setAtributes($parentElement, $node->getAttr('parent'));
-
             } else {
                 $parentNode->appendChild($nodeElement);
             }
-
         } else {
             $this->element->appendChild($nodeElement);
         }

--- a/src/CFDI/Common/Node.php
+++ b/src/CFDI/Common/Node.php
@@ -29,6 +29,12 @@ class Node
     protected $nodeName = '';
 
     /**
+     * Define the parent node name, rename this attribute in inherit class
+     * @var string|null
+     */
+    protected $parentNodeName = null;
+
+    /**
      * Node document.
      *
      * @var \DOMDocument
@@ -211,7 +217,7 @@ class Node
      */
     public function getParentNodeName()
     {
-        return (isset($this->parentNodeName)) ? $this->parentNodeName : null;
+        return $this->parentNodeName;
     }
 
     /**

--- a/src/CFDI/Node/Complemento/TimbreFiscalDigital.php
+++ b/src/CFDI/Node/Complemento/TimbreFiscalDigital.php
@@ -11,8 +11,6 @@
 
 namespace Charles\CFDI\Node\Complemento;
 
-use Charles\CFDI\Common\Node;
-
 /**
  * This is the timbre fiscal class.
  *

--- a/src/CFDI/Node/Comprobante.php
+++ b/src/CFDI/Node/Comprobante.php
@@ -39,8 +39,6 @@ class Comprobante extends Node
      *
      * @param array   $data
      * @param string  $version
-     *
-     * @return void
      */
     public function __construct($data, $version)
     {


### PR DESCRIPTION
Declare protected variables `Node::$parentNodeName` and `Node::$nodeName`. It is easy to go to classes where this variables are overriden.
On `Node::getNodeName()` throw exception if `Node::$nodeName` is not a string or is empty
Fix docblocks where type was missing or incorrect
Add fixes to use PSR-2
Remove unused imports (`use` statements)

Note: PhpStorm inspections are clean